### PR TITLE
fix: adapt processProjectGraph to work w/ Nx >= 16.3.0

### DIFF
--- a/libs/vue/src/processProjectGraph.ts
+++ b/libs/vue/src/processProjectGraph.ts
@@ -117,7 +117,7 @@ export async function processProjectGraph(
   //ensure changed files are in the node of the graph
   for (const r of res) {
     if (
-      !graph.nodes[r.sourceProjectName].data.files.some(
+      !context.fileMap[r.sourceProjectName].data.files.some(
         (f: FileData) => f.file == r.sourceProjectFile
       )
     ) {


### PR DESCRIPTION
>files attribute was removed from ProjectConfiguration type in version 16.3.0


## Current Behavior
Any action which triggers the project graph to be computed, causes an error with nx-vue graph extension plugin


## Expected Behavior
Should process the files

## Related Issue(s)

https://github.com/nrwl/nx/issues/17563


Fixes #3
